### PR TITLE
Add configuration to disable site access based on a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,19 @@
 App to manage ERPNext User, Company and Space limitations
 
 #### How to Install
-bench get-app --branch master erpnext_quota https://github.com/ahmadpak/erpnext_quota
-bench include-app erpnext_quota
-bench --site *site_name* install-app erpnext_quota
+
+```bench get-app --branch master erpnext_quota https://github.com/ahmadpak/erpnext_quota```
+
+```bench include-app erpnext_quota```
+
+```bench --site *site_name* install-app erpnext_quota```
 
 ### Usage
-Install the app. It will create a file quota.json in site directory
-Contents will look similar:
+Install the app. It will create a file quota.json in site directory.
 
+Contents will look similar to:
+
+```
 {
   "users": 5,
   "active_users": 1,
@@ -27,9 +32,10 @@ Contents will look similar:
   "backup_files_size": 2,
   "used_db_space": 28
 }
-
+```
 
 Manually change the default values to change the limits. 
+
 Default is:
 - 5 active users not including website users
 - 2 companies

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -84,7 +84,7 @@ def validate_db_space_limit():
     msg += '<ul><li>Allowed Space: {}MB</li><li>Used Space: {}MB</li></ul>'.format(allowed_db_space, used_db_space)
     frappe.throw(_(msg))
 
-def handle_unified_space_limit(self, method):
+def handle_unified_space_limit():
   with open(frappe.get_site_path('quota.json')) as jsonfile:
       parsed = json.load(jsonfile)
 

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -90,8 +90,8 @@ def handle_unified_space_limit():
 
   allowed_storage = parsed["space"]
     
-  used_files_storage = parsed['used_space']
-  used_db_storage    = parsed['used_db_space']
+  used_files_storage = parsed['used_space'] if 'used_space' in parsed else 0
+  used_db_storage    = parsed['used_db_space'] if 'used_db_space' in parsed else 0
 
   total_used_storage = used_files_storage + used_db_storage
 
@@ -102,7 +102,7 @@ def handle_unified_space_limit():
     '<div>',
     _('You have exceeded your storage limit.'),
     '<br>',
-    _('Delete some files to free storage or contact sales to upgrade your package'),
+    _('Delete some files to free storage or contact sales to upgrade your storage limit'),
     '</div>',
     '<ul><li>',
     _('Allowed Storage: {0}MB').format(allowed_storage),

--- a/erpnext_quota/events/auth.py
+++ b/erpnext_quota/events/auth.py
@@ -9,5 +9,9 @@ def successful_login(login_manager):
     
     valid_till = parsed['valid_till']
     diff = date_diff(valid_till, today())
-    if diff < 0:
+
+    site_suspended = 'site_suspended' in parsed and parsed['site_suspended']
+    
+    disable_access = diff < 0 or site_suspended
+    if disable_access:
         frappe.throw(_("You site is suspended. Please contact Sales"), frappe.AuthenticationError)

--- a/erpnext_quota/install.py
+++ b/erpnext_quota/install.py
@@ -34,7 +34,8 @@ def before_install():
     'used_company': 1,
     'count_website_users': 0,
     'count_administrator_user': 0,
-    'valid_till': add_days(today(), 14)
+    'valid_till': add_days(today(), 14),
+    'site_disabled': False
   }
   with open(frappe.get_site_path('quota.json'), 'w') as outfile:
     json.dump(data, outfile, indent= 2)

--- a/erpnext_quota/install.py
+++ b/erpnext_quota/install.py
@@ -35,7 +35,8 @@ def before_install():
     'count_website_users': 0,
     'count_administrator_user': 0,
     'valid_till': add_days(today(), 14),
-    'site_disabled': False
+    'site_disabled': False,
+    'unified_space_limit': False
   }
   with open(frappe.get_site_path('quota.json'), 'w') as outfile:
     json.dump(data, outfile, indent= 2)

--- a/erpnext_quota/install.py
+++ b/erpnext_quota/install.py
@@ -35,7 +35,7 @@ def before_install():
     'count_website_users': 0,
     'count_administrator_user': 0,
     'valid_till': add_days(today(), 14),
-    'site_disabled': False,
+    'site_suspended': False,
     'unified_space_limit': False
   }
   with open(frappe.get_site_path('quota.json'), 'w') as outfile:

--- a/erpnext_quota/tasks.py
+++ b/erpnext_quota/tasks.py
@@ -1,5 +1,5 @@
 from erpnext_quota.erpnext_quota.quota import validate_files_space_limit, validate_db_space_limit
 
 def daily():
-    validate_files_space_limit()
     validate_db_space_limit()
+    validate_files_space_limit()


### PR DESCRIPTION
Sometimes it is useful to just have a configuration flag to disable a site, not based on a date. 
This PR adds that feature, while still being able to disable access through a limit date.