### PR TITLE
feat: Document limit

### DIFF
--- a/erpnext_quota/erpnext_quota/doctype/quota_document_limit_detail/quota_document_limit_detail.json
+++ b/erpnext_quota/erpnext_quota/doctype/quota_document_limit_detail/quota_document_limit_detail.json
@@ -1,0 +1,49 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-03-01 21:01:37.958915",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "document_type",
+  "limit",
+  "period"
+ ],
+ "fields": [
+  {
+   "fieldname": "document_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Document Type",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "limit",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Limit",
+   "reqd": 1
+  },
+  {
+   "default": "Daily",
+   "fieldname": "period",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Period",
+   "options": "Daily\nWeekly\nMonthly",
+   "reqd": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2023-03-01 21:01:37.958915",
+ "modified_by": "Administrator",
+ "module": "Erpnext Quota",
+ "name": "Quota Document Limit Detail",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/erpnext_quota/erpnext_quota/doctype/quota_document_limit_detail/quota_document_limit_detail.json
+++ b/erpnext_quota/erpnext_quota/doctype/quota_document_limit_detail/quota_document_limit_detail.json
@@ -7,8 +7,12 @@
  "engine": "InnoDB",
  "field_order": [
   "document_type",
+  "period",
   "limit",
-  "period"
+  "column_break_vjt7h",
+  "usage",
+  "from_date",
+  "to_date"
  ],
  "fields": [
   {
@@ -34,11 +38,34 @@
    "label": "Period",
    "options": "Daily\nWeekly\nMonthly",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "usage",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Usage"
+  },
+  {
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "From Date"
+  },
+  {
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "To Date"
+  },
+  {
+   "fieldname": "column_break_vjt7h",
+   "fieldtype": "Column Break"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-03-01 21:01:37.958915",
+ "modified": "2023-03-05 14:07:37.765300",
  "modified_by": "Administrator",
  "module": "Erpnext Quota",
  "name": "Quota Document Limit Detail",

--- a/erpnext_quota/erpnext_quota/doctype/quota_document_limit_detail/quota_document_limit_detail.py
+++ b/erpnext_quota/erpnext_quota/doctype/quota_document_limit_detail/quota_document_limit_detail.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Havenir Solutions Private Limited and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class QuotaDocumentLimitDetail(Document):
+	pass

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.js
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.js
@@ -15,3 +15,19 @@ frappe.ui.form.on('Usage Info', {
 		frm.disable_save();
 	}
 });
+
+
+frappe.ui.form.on('Quota Document Limit Detail', {
+	document_limit_add: function (frm, cdt, cdn){
+		frm.set_query('document_type', 'document_limit', () => {
+			return {
+				filters: {
+					issingle: 0,
+					istable: 0,
+					module: ["!=", "Core"],
+					name: ["NOT IN", "Email Queue", "Notification Log"]
+				}
+			}
+		})
+	}
+});

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.json
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.json
@@ -9,7 +9,6 @@
   "users",
   "space",
   "company",
-  "sales_invoice",
   "column_break_3",
   "active_users",
   "used_space",
@@ -118,11 +117,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "sales_invoice",
-   "fieldtype": "Data",
-   "label": "Sales Invoice "
-  },
-  {
    "fieldname": "document_limit_section",
    "fieldtype": "Section Break",
    "label": "Document Limit"
@@ -138,7 +132,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-03-01 21:57:49.498357",
+ "modified": "2023-03-05 12:34:56.681577",
  "modified_by": "Administrator",
  "module": "Erpnext Quota",
  "name": "Usage Info",

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.json
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.json
@@ -131,13 +131,14 @@
    "fieldname": "document_limit",
    "fieldtype": "Table",
    "label": "Document Limit",
-   "options": "Quota Document Limit Detail"
+   "options": "Quota Document Limit Detail",
+   "read_only": 1
   }
  ],
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-03-01 21:02:31.207777",
+ "modified": "2023-03-01 21:57:49.498357",
  "modified_by": "Administrator",
  "module": "Erpnext Quota",
  "name": "Usage Info",

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.json
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.json
@@ -9,6 +9,7 @@
   "users",
   "space",
   "company",
+  "sales_invoice",
   "column_break_3",
   "active_users",
   "used_space",
@@ -21,7 +22,9 @@
   "database_details_section",
   "db_space",
   "column_break_15",
-  "used_db_space"
+  "used_db_space",
+  "document_limit_section",
+  "document_limit"
  ],
  "fields": [
   {
@@ -113,12 +116,28 @@
    "fieldtype": "Int",
    "label": "Active Company",
    "read_only": 1
+  },
+  {
+   "fieldname": "sales_invoice",
+   "fieldtype": "Data",
+   "label": "Sales Invoice "
+  },
+  {
+   "fieldname": "document_limit_section",
+   "fieldtype": "Section Break",
+   "label": "Document Limit"
+  },
+  {
+   "fieldname": "document_limit",
+   "fieldtype": "Table",
+   "label": "Document Limit",
+   "options": "Quota Document Limit Detail"
   }
  ],
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-16 12:03:08.056014",
+ "modified": "2023-03-01 21:02:31.207777",
  "modified_by": "Administrator",
  "module": "Erpnext Quota",
  "name": "Usage Info",

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.py
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.py
@@ -24,9 +24,9 @@ class UsageInfo(Document):
         for key, value in usage.items():
             self.db_set(key, value)
 
+        # update document list table
         frappe.db.truncate("Quota Document Limit Detail")
         self.reload()
-        # update document list table
         for item in document_limit:
             self.append('document_limit', item)
         self.save()

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.py
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.py
@@ -13,8 +13,21 @@ class UsageInfo(Document):
     def get_usage_info(self):
         quota = frappe.get_site_config()['quota']
         usage = {}
+
         for key, value in quota.items():
             usage[key] = value
-
+        
+        # copy out document_limit and remove from dict
+        document_limit = usage['document_limit']
+        del usage['document_limit']
+        
         for key, value in usage.items():
             self.db_set(key, value)
+
+        frappe.db.truncate("Quota Document Limit Detail")
+        self.reload()
+        # update document list table
+        for item in document_limit:
+            self.append('document_limit', item)
+        self.save()
+        self.reload()

--- a/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.py
+++ b/erpnext_quota/erpnext_quota/doctype/usage_info/usage_info.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document
+from erpnext_quota.erpnext_quota.quota import get_limit_period
 
 
 class UsageInfo(Document):
@@ -27,7 +28,15 @@ class UsageInfo(Document):
         # update document list table
         frappe.db.truncate("Quota Document Limit Detail")
         self.reload()
-        for item in document_limit:
-            self.append('document_limit', item)
+        for key, value in document_limit.items():
+            period = get_limit_period(value['period'])
+            value['usage'] = len(frappe.db.get_list(key, 
+                {'creation': ["BETWEEN", 
+                    [f"{period.start} 00:00:00.000000", f"{period.end} 23:23:59.999999"]]})
+            )
+            value['document_type'] = key
+            value['from_date'] = period.start
+            value['to_date'] = period.end
+            self.append('document_limit', value)
         self.save()
         self.reload()

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -3,7 +3,7 @@ import subprocess
 import frappe
 from frappe import _
 from frappe.installer import update_site_config
-from frappe.utils import getdate, add_days, add_months
+from frappe.utils import (getdate, add_days, add_months, get_first_day, get_last_day)
 
 
 # User
@@ -217,6 +217,6 @@ def get_limit_period(period):
     periods = {
         'Daily': {'start': str(today), 'end': str(today)},
         'Weekly': {'start': str(add_days(start, -1)), 'end': str(add_days(end, -1))},
-        'Monthly': {'start': str(add_months(today, -1)), 'end': str(today)},
+        'Monthly': {'start': str(get_first_day(today)), 'end': str(get_last_day(today))},
     }
     return frappe._dict(periods.get(period))

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -191,18 +191,18 @@ def get_directory_size(path):
 
 def document_limit(doc, event):
     # store limits docs in dictionary
-    limit_dict = {}
-    for item in frappe.get_site_config()['quota']['document_limit']:
-        limit_dict[item['document_type']] = item
-
+    limit_dict = frappe.get_site_config()['quota']['document_limit']
+    print(limit_dict)
     # match the limit based on period and limit number
+    print(limit_dict.get(doc.doctype))
     if (limit_dict.get(doc.doctype)):
         limit = frappe._dict(limit_dict.get(doc.doctype))
         limit_period = get_limit_period(limit.period)
-        if len(frappe.db.get_list(doc.doctype, filters={
+        usage = len(frappe.db.get_list(doc.doctype, filters={
             'creation': ['BETWEEN', [str(limit_period.start)+' 00:00:00.000000', 
                 str(limit_period.end)+' 23:59:59.999999']]
-            })) >= limit.limit:
+            }))
+        if usage >= limit.limit:
             msg = _(f"Limit exceeded for {doc.doctype}, {limit.period} limit is {limit.limit}. Please contact administrator.")
             frappe.throw(msg)
 

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -203,17 +203,20 @@ def document_limit(doc, event):
             'creation': ['BETWEEN', [str(limit_period.start)+' 00:00:00.000000', 
                 str(limit_period.end)+' 23:59:59.999999']]
             })) >= limit.limit:
-            msg = f"Limit exceeded for {doc.doctype}, {limit.period} limit is {limit.limit}. Please contact administrator."
+            msg = _(f"Limit exceeded for {doc.doctype}, {limit.period} limit is {limit.limit}. Please contact administrator.")
             frappe.throw(msg)
 
 def get_limit_period(period):
     """
         Get date mappinf for document limit period
     """
-    today = str(getdate())
+    from datetime import date, timedelta
+    today = date.today()
+    start = today - timedelta(days=today.weekday())
+    end = start + timedelta(days=6)
     periods = {
-        'Daily': {'start': today, 'end': today},
-        'Weekly': {'start': add_days(today, -6), 'end': today},
-        'Monthly': {'start': add_months(today, -1), 'end': today},
+        'Daily': {'start': str(today), 'end': str(today)},
+        'Weekly': {'start': str(add_days(start, -1)), 'end': str(add_days(end, -1))},
+        'Monthly': {'start': str(add_months(today, -1)), 'end': str(today)},
     }
     return frappe._dict(periods.get(period))

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -1,5 +1,5 @@
 import subprocess
-
+from datetime import date, timedelta
 import frappe
 from frappe import _
 from frappe.installer import update_site_config
@@ -210,7 +210,6 @@ def get_limit_period(period):
     """
         Get date mappinf for document limit period
     """
-    from datetime import date, timedelta
     today = date.today()
     start = today - timedelta(days=today.weekday())
     end = start + timedelta(days=6)

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -216,7 +216,7 @@ def get_limit_period(period):
     end = start + timedelta(days=6)
     periods = {
         'Daily': {'start': str(today), 'end': str(today)},
-        'Weekly': {'start': str(add_days(start, -1)), 'end': str(add_days(end, -1))},
+        'Weekly': {'start': str(start), 'end': str(end)},
         'Monthly': {'start': str(get_first_day(today)), 'end': str(get_last_day(today))},
     }
     return frappe._dict(periods.get(period))

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -195,6 +195,7 @@ def document_limit(doc, event):
     for item in frappe.get_site_config()['quota']['document_limit']:
         limit_dict[item['document_type']] = item
 
+    # match the limit based on period and limit number
     if (limit_dict.get(doc.doctype)):
         limit = frappe._dict(limit_dict.get(doc.doctype))
         limit_period = get_limit_period(limit.period)
@@ -204,12 +205,11 @@ def document_limit(doc, event):
             })) >= limit.limit:
             msg = f"Limit exceeded for {doc.doctype}, {limit.period} limit is {limit.limit}. Please contact administrator."
             frappe.throw(msg)
-        print({
-            'creation': ['BETWEEN', [str(limit_period.start)+' 00:00:00.000000', 
-                str(limit_period.end)+' 23:59:59.999999']]
-            }, doc.doctype)
 
 def get_limit_period(period):
+    """
+        Get date mappinf for document limit period
+    """
     today = str(getdate())
     periods = {
         'Daily': {'start': today, 'end': today},

--- a/erpnext_quota/erpnext_quota/quota.py
+++ b/erpnext_quota/erpnext_quota/quota.py
@@ -190,11 +190,10 @@ def get_directory_size(path):
     return int(total_size)
 
 def document_limit(doc, event):
-    # store limits docs in dictionary
+    """
+    We check for the doctype in document_limit and compute accordingly.
+    """
     limit_dict = frappe.get_site_config()['quota']['document_limit']
-    print(limit_dict)
-    # match the limit based on period and limit number
-    print(limit_dict.get(doc.doctype))
     if (limit_dict.get(doc.doctype)):
         limit = frappe._dict(limit_dict.get(doc.doctype))
         limit_period = get_limit_period(limit.period)

--- a/erpnext_quota/hooks.py
+++ b/erpnext_quota/hooks.py
@@ -98,7 +98,8 @@ doc_events = {
         'on_update': 'erpnext_quota.erpnext_quota.quota.company_limit'
     },
     '*': {
-        'on_submit': 'erpnext_quota.erpnext_quota.quota.db_space_limit'
+        'on_submit': 'erpnext_quota.erpnext_quota.quota.db_space_limit',
+        'before_insert': 'erpnext_quota.erpnext_quota.quota.document_limit'
     },
     'File': {
         'validate': 'erpnext_quota.erpnext_quota.quota.files_space_limit'

--- a/erpnext_quota/install.py
+++ b/erpnext_quota/install.py
@@ -37,13 +37,12 @@ def before_install():
         'count_website_users': 0,
         'count_administrator_user': 0,
         'valid_till': add_days(today(), 14),
-        'document_limit': [
-            {
-                'document_type': 'Sales Invoice',
-                'limit': 1,
-                'period': 'Daily'
-            }
-        ]
+        'document_limit': {
+            "Sales Invoice": {'limit': 10, 'period': 'Daily', 'usage': 0},
+            "Purchase Invoice": {'limit': 10, 'period': 'Weekly', 'usage': 0},
+            "Journal Entry": {'limit': 10, 'period': 'Monthly', 'usage': 0},
+            "Payment Entry": {'limit': 10, 'period': 'Monthly', 'usage': 0}
+        }
     }
 
     # Updating site config

--- a/erpnext_quota/install.py
+++ b/erpnext_quota/install.py
@@ -36,7 +36,14 @@ def before_install():
         'used_company': 1,
         'count_website_users': 0,
         'count_administrator_user': 0,
-        'valid_till': add_days(today(), 14)
+        'valid_till': add_days(today(), 14),
+        'document_limit': [
+            {
+                'document_type': 'Sales Invoice',
+                'limit': 1,
+                'period': 'Daily'
+            }
+        ]
     }
 
     # Updating site config

--- a/erpnext_quota/install.py
+++ b/erpnext_quota/install.py
@@ -38,10 +38,10 @@ def before_install():
         'count_administrator_user': 0,
         'valid_till': add_days(today(), 14),
         'document_limit': {
-            "Sales Invoice": {'limit': 10, 'period': 'Daily', 'usage': 0},
-            "Purchase Invoice": {'limit': 10, 'period': 'Weekly', 'usage': 0},
-            "Journal Entry": {'limit': 10, 'period': 'Monthly', 'usage': 0},
-            "Payment Entry": {'limit': 10, 'period': 'Monthly', 'usage': 0}
+            "Sales Invoice": {'limit': 10, 'period': 'Daily'},
+            "Purchase Invoice": {'limit': 10, 'period': 'Weekly'},
+            "Journal Entry": {'limit': 10, 'period': 'Monthly'},
+            "Payment Entry": {'limit': 10, 'period': 'Monthly'}
         }
     }
 


### PR DESCRIPTION
This feature adds document (doctype) limit to erpnext_quota, the limits are defined as follow:

 1. **Document Type(document_type)**: doctype to be limited
 2. **Period(period)**: time space in which the limit should be applied, it could be:
	 - **Daily** same day (2023-03-05, 2023-03-05)
	 - **Weekly**: from Monday to Sunday of current day. (2023-02-27, 2023-03-05)
	 - **Monthly**: month start to month end of current day (2023-03-01, 2023-03-31)
 3. **Limit**: total number of document that should be created within the period.

The configuration by default will be added to site_config.json with key document_limit.
current default values:
        'document_limit': {
            "Sales Invoice": {'limit': 10, 'period': 'Daily'},
            "Purchase Invoice": {'limit': 10, 'period': 'Weekly'},
            "Journal Entry": {'limit': 10, 'period': 'Monthly'},
            "Payment Entry": {'limit': 10, 'period': 'Monthly'}
        }

This values can be updated.
**Screenshot**
- Usage Info
- 
![image](https://user-images.githubusercontent.com/10146518/222963043-e557470c-2bd8-4303-8fba-d596f2265813.png)
![image](https://user-images.githubusercontent.com/10146518/222963072-940036ac-687d-4f73-8e04-0bdb0765adee.png)


- Validation Message
![image](https://user-images.githubusercontent.com/10146518/222278781-6fcc4de5-8b7b-4930-afb7-6ba431129d16.png)

![image](https://user-images.githubusercontent.com/10146518/222278888-12d97dc8-5226-435d-bc8d-837dc5d451c9.png)
